### PR TITLE
Auto-switch to Media Stream page when source changes

### DIFF
--- a/packages/pages/ddp-stream.yaml
+++ b/packages/pages/ddp-stream.yaml
@@ -53,6 +53,16 @@ lvgl:
               id(output_video).stop();
 
 # -----------------------------
+# Auto-switch page when source changes
+# -----------------------------
+switch:
+  - platform: template
+    id: video_src_auto_switch_page
+    name: "Auto-switch to ${page_friendly_name} on source change"
+    optimistic: true
+    restore_mode: RESTORE_DEFAULT_ON
+
+# -----------------------------
 # Runtime source change
 # -----------------------------
 text:
@@ -70,3 +80,13 @@ text:
         - media_proxy_control.set_source:
             id: output_video
             src: !lambda "return x;"
+        # Only jump to the stream page on real runtime changes (API connected),
+        # not on boot-time replays of the restored value.
+        - if:
+            condition:
+              and:
+                - switch.is_on: video_src_auto_switch_page
+                - lambda: 'return api::global_api_server != nullptr && api::global_api_server->is_connected();'
+            then:
+              - lvgl_page_manager.page.show:
+                  page: ddp_video

--- a/packages/pages/ddp-stream.yaml
+++ b/packages/pages/ddp-stream.yaml
@@ -51,6 +51,7 @@ lvgl:
         then:
           - lambda: |-
               id(output_video).stop();
+              lv_canvas_fill_bg(id(video_canvas), lv_color_black(), LV_OPA_COVER);
 
 # -----------------------------
 # Auto-switch page when source changes

--- a/packages/pages/ddp-stream.yaml
+++ b/packages/pages/ddp-stream.yaml
@@ -59,6 +59,7 @@ switch:
   - platform: template
     id: video_src_auto_switch_page
     name: "Auto-switch to ${page_friendly_name} on source change"
+    entity_category: config
     optimistic: true
     restore_mode: RESTORE_DEFAULT_ON
 


### PR DESCRIPTION
## Summary
- Adds a template switch `Auto-switch to Media Stream on source change` (default on, persisted across reboots) to `packages/pages/ddp-stream.yaml`.
- When enabled, updating the `Media Source` text entity at runtime navigates the display to the `ddp_video` page automatically — a small QoL win so users don't have to flip pages manually after pushing a new URL from Home Assistant.
- Gated on `api::global_api_server->is_connected()` so the boot-time `restore_value` replay of the saved source does **not** pull the display off whatever default page the device normally lands on. Existing behavior is preserved on boot.

## Test plan
- [x] Tested on a fork build with an Apollo M-1 rev6.
- [x] With switch on: changing `Media Source` from HA flips the display to Media Stream.
- [x] With switch off: changing `Media Source` updates the stream but the display stays on the current page.
- [x] Reboot with switch on: display lands on the normal default page (BIOS → default), not Media Stream.

Happy to adjust the default (on vs. off) or the entity name if you'd prefer something different.