### PR TITLE
Bump lvgl-canvas-fx to v0.4.1 (fix ESPHome 2026.7 build)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v0.2.0
 
 ## [Unreleased]
 
+### Changed
+- Bumped lvgl-canvas-fx to v0.4.1 (fixes ESPHome 2026.7 code-generation failure on the chipmunk2d library spec)
+
 ## [v0.6.1] - 2025-10-21
 
 ### Changed

--- a/packages/pages/audio-spectrum.yaml
+++ b/packages/pages/audio-spectrum.yaml
@@ -14,7 +14,7 @@ lvgl_page_manager:
       friendly_name: "${page_friendly_name}"
 
 external_components:
-  - source: github://pavlov-net/lvgl-canvas-fx@v0.4.0
+  - source: github://pavlov-net/lvgl-canvas-fx@v0.4.1
 
 # ---- Microphone Configuration ----
 # Hardware: I²S digital microphone

--- a/packages/pages/fx.yaml
+++ b/packages/pages/fx.yaml
@@ -14,7 +14,7 @@ lvgl_page_manager:
       friendly_name: "${page_friendly_name}"
 
 external_components:
-  - source: github://pavlov-net/lvgl-canvas-fx@v0.4.0
+  - source: github://pavlov-net/lvgl-canvas-fx@v0.4.1
 
 select:
   - platform: template


### PR DESCRIPTION
Bumps the lvgl-canvas-fx external component from v0.4.0 to v0.4.1 in both pages that use it.

v0.4.0 fails code generation on ESPHome 2026.7:

    platformio.package.exception.UnknownPackageError: Could not find the
    package with 'https://github.com/stuartparmenter/chipmunk2d-platformio'
    requirements

2026.7 converts PlatformIO libraries to ESP-IDF components, and the resolver splits the bare git URL passed as the library name into a registry lookup that doesn't exist. v0.4.1 (pavlov-net/lvgl-canvas-fx#4) passes the name and repo separately so the resolver takes the git path.

Pins updated in packages/pages/fx.yaml and packages/pages/audio-spectrum.yaml.
