### PR TITLE
CI: skip the remote (non-factory) build on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,11 @@ jobs:
     steps:
       - name: Checkout source code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # The non-factory config pulls its packages from a remote_package pinned
+      # to @main, so on a pull_request it builds main's code, not the PR's, and
+      # can't validate the change. Run it only where main == the built code.
       - name: ESPHome ${{ matrix.esphome-version }}
+        if: github.event_name != 'pull_request'
         uses: esphome/build-action@4ef4722a2935eac47b7e227fe0e1f8e0f8afcc42 # v7.3.0
         with:
           yaml-file: ${{ matrix.file }}.yaml


### PR DESCRIPTION
The non-factory `<board>.yaml` configs pull their page packages from a `remote_package_files` block pinned to this repo `@main`:

    packages:
      remote_package_files:
        url: https://github.com/pavlov-net/hub75-studio
        ref: main
        refresh: 0s

So on a `pull_request`, that build step fetches main's copy of the packages, not the PR's. It can't validate the change, and it fails whenever main is broken relative to the fix the PR carries. Example: in #127's CI run, the non-factory step failed building main's v0.4.0 pin, and that failure also skipped the factory step, so the PR's actual files were never built at all.

This gates the non-factory step to non-`pull_request` events. The factory `<board>.factory.yaml` build (local includes) still runs on PRs and validates the actual changed files. The remote build keeps running on push to main and on the weekly cron, where `@main` is the code being tested, so its purpose as a "does the live user-facing config still compile" canary is unchanged.

Note this does not make PR CI green by itself. On this PR's own run the non-factory step now skips as intended, and the factory build then fails on the pre-existing chipmunk2d dependency breakage that is also failing CI on main. PRs stay red until that is fixed; the change just makes PR CI build the PR's own code instead of main's.
