### PR TITLE
Fix timer page hardcoding friendly name instead of page_friendly_name

### DIFF
--- a/packages/pages/timer.yaml
+++ b/packages/pages/timer.yaml
@@ -12,7 +12,7 @@
 lvgl_page_manager:
   pages:
     - page: page_timer${uid}
-      friendly_name: "Timer"
+      friendly_name: "${page_friendly_name}"
 
 # Fetch timer state from Home Assistant
 text_sensor:


### PR DESCRIPTION
The timer page manager entry hardcoded `friendly_name: "Timer"`, but the file documents `page_friendly_name` as a required var and every other page uses `friendly_name: "${page_friendly_name}"`. Since the page id is uid-scoped (`page_timer${uid}`), two timer instances would both show "Timer" in the page selector and any custom name passed in was silently discarded.

One-line fix to match the other pages.
