### PR TITLE
Fix fx page select for ESPHome 2026.7 (use current_option())

### DIFF
--- a/packages/pages/fx.yaml
+++ b/packages/pages/fx.yaml
@@ -52,7 +52,7 @@ lvgl:
           # Keep the selected option authoritative: sync effect to current select value
           - lvgl_canvas_fx.set_effect:
               id: cfx
-              effect: !lambda 'return id(fx_effect_select).state;'
+              effect: !lambda 'return id(fx_effect_select).current_option();'
           - lvgl_canvas_fx.resume:
               id: cfx
       on_unload:


### PR DESCRIPTION
## What

ESPHome 2026.7 removed the long-deprecated public `Select::state` member. The fx page's `on_load` lambda read `id(fx_effect_select).state` to re-sync the active effect to the current select value, which now fails to compile in the CI build:

```
packages/pages/fx.yaml:55: error:
'class esphome::template_::TemplateSelectWithSetAction<false, true, false, 1>'
has no member named 'state'
```

## Fix

Use `Select::current_option()` instead. It returns a `StringRef` that implicitly converts to the `std::string` the `lvgl_canvas_fx.set_effect` action expects (`TEMPLATABLE_VALUE(std::string, effect)`) — the same conversion the select's own `set_action` already relies on via `return x;`.

```diff
-              effect: !lambda 'return id(fx_effect_select).state;'
+              effect: !lambda 'return id(fx_effect_select).current_option();'
```

## Notes

This is one of two independent errors in the failing 2026.7 CI job; the `bios.yaml` `esp_chip_info` failure is being handled separately.