### PR TITLE
Fix bios page for ESPHome 2026.7 (drop -include build flags)

### DIFF
--- a/packages/pages/bios.yaml
+++ b/packages/pages/bios.yaml
@@ -1,12 +1,6 @@
 # © Copyright 2025 Stuart Parmenter
 # SPDX-License-Identifier: MIT
 
-esphome:
-  platformio_options:
-    build_src_flags:
-      - -include esp_chip_info.h
-      - -include esp_mac.h
-
 wifi:
   on_connect:
     then:
@@ -86,22 +80,7 @@ lvgl:
                 x: 2
                 y: 22
                 styles: [st_spleen8]
-                text: !lambda |-
-                  esp_chip_info_t ci;
-                  esp_chip_info(&ci);
-                  const char *model = "ESP32";
-                  switch (ci.model) {
-                    case CHIP_ESP32:   model = "ESP32";    break;
-                    case CHIP_ESP32S2: model = "ESP32-S2"; break;
-                    case CHIP_ESP32S3: model = "ESP32-S3"; break;
-                    case CHIP_ESP32C3: model = "ESP32-C3"; break;
-                    case CHIP_ESP32C6: model = "ESP32-C6"; break;
-                    case CHIP_ESP32H2: model = "ESP32-H2"; break;
-                    default:           model = "ESP32";    break;
-                  }
-                  char buf[32];
-                  snprintf(buf, sizeof(buf), "CPU:%s", model);
-                  return std::string(buf);
+                text: !lambda 'return std::string("CPU:" ESPHOME_VARIANT);'
             - label:
                 id: bios_mem
                 x: 2
@@ -125,7 +104,7 @@ lvgl:
                 styles: [st_spleen8]
                 text: !lambda |-
                   uint8_t mac[6] = {0};
-                  esp_read_mac(mac, ESP_MAC_WIFI_STA);
+                  get_mac_address_raw(mac);
                   char buf[32];
                   snprintf(buf, sizeof(buf), "ID:%02X%02X%02X", mac[3], mac[4], mac[5]);
                   return std::string(buf);


### PR DESCRIPTION
## What

The bios page force-included two ESP-IDF headers via PlatformIO build flags:

```yaml
esphome:
  platformio_options:
    build_src_flags:
      - -include esp_chip_info.h
      - -include esp_mac.h
```

In ESPHome 2026.7 these `-include` flags no longer reach the lambda translation units, so the CPU lambda fails to compile in CI:

```
packages/pages/bios.yaml:90: error:
'esp_chip_info_t' was not declared in this scope; did you mean 'i2s_chan_info_t'?
```

Inlining `#include "esp_chip_info.h"` into the lambda (as the version/mem lambdas do with `esp_app_desc.h` / `esp_heap_caps.h`) is **not** viable here: those two headers are already pulled in transitively, so their inline includes are guarded no-ops. `esp_chip_info.h` is not otherwise included, so its body — including its `extern "C" { … }` block — would expand inside the lambda's function scope, which is ill-formed (a linkage-specification may only appear at namespace scope).

## Fix

Use compile-time info that needs no ESP-IDF header:

- **CPU line** → `ESPHOME_VARIANT`. This `#define` (emitted by the esp32 component into `esphome/core/defines.h`) resolves to the `VARIANT_FRIENDLY` string — `"ESP32"`, `"ESP32-S2"`, `"ESP32-S3"`, `"ESP32-C3"`, `"ESP32-C6"`, `"ESP32-H2"`, … — which is **byte-for-byte identical** to the old `switch` statement's output.
- **ID line** → `get_mac_address_raw()` from `esphome/core/helpers.h` (always included). It fills the same base/STA MAC bytes as `esp_read_mac(mac, ESP_MAC_WIFI_STA)`, so the `ID:XXXXXX` output is unchanged.

Net effect: identical on-screen text, and the `esp_chip_info.h` + `esp_mac.h` dependencies (and the whole `build_src_flags` block) are gone.

## Notes

`ESPHOME_VARIANT` reflects the target the firmware was **built for** rather than a runtime silicon probe — equivalent in practice since these are built per-target.

Second of two independent 2026.7 CI errors; the fx.yaml `select.state` fix is #131.