### PR TITLE
Bump ESPHome to 2026.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # HUB75 Studio
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![ESPHome](https://img.shields.io/badge/ESPHome-2026.5-blue)](https://esphome.io/)
+[![ESPHome](https://img.shields.io/badge/ESPHome-2026.7-blue)](https://esphome.io/)
 [![Python](https://img.shields.io/badge/Python-3.11+-blue)](https://www.python.org/)
 
 **Transform your HUB75 LED matrix into a smart display for Home Assistant.**
@@ -39,7 +39,7 @@ Built on **ESPHome** with **LVGL** for smooth graphics, everything integrates se
 
 **For Building from Source (Optional):**
 - **Python 3.11+** required for ESPHome toolchain
-- **ESPHome 2026.5.x** with ESP‑IDF framework (Arduino not supported)
+- **ESPHome 2026.7.x** with ESP‑IDF framework (Arduino not supported)
 - **Home Assistant** for full integration features
 
 **For Using Prebuilt Firmware:**

--- a/packages/common/esphome-version.yaml
+++ b/packages/common/esphome-version.yaml
@@ -3,4 +3,4 @@
 
 # Enforce minimum ESPHome version
 esphome:
-  min_version: 2026.5.0
+  min_version: 2026.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "ESPHome project for HUB75 matrix controllers"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "esphome>=2026.6.5,<2026.7",
+    "esphome>=2026.7.0,<2026.8",
     # PlatformIO (used by ESPHome for ESP-IDF builds) expects pip to be available
     "pip",
 ]


### PR DESCRIPTION
Bumps the project's ESPHome floor to 2026.7.

- **`pyproject.toml`** — `esphome>=2026.7.0,<2026.8`. The previous pin was `>=2026.6.5,<2026.7`, whose upper bound *excluded* 2026.7 entirely.
- **`packages/common/esphome-version.yaml`** — `min_version: 2026.7.0` (was `2026.5.0`).
- **`README.md`** — badge and "For Building from Source" requirement updated to `2026.7.x`.
