### PR TITLE
Fix deprecated LVGL disp_bg_color warning (use bottom_layer)

### DIFF
--- a/packages/common/theme.yaml
+++ b/packages/common/theme.yaml
@@ -32,7 +32,8 @@ lvgl:
       text_color: white
 
   # Screen (display) background behind everything
-  disp_bg_color: black
+  bottom_layer:
+    bg_color: black
 
   # Make Spleen 8 the default font everywhere
   default_font: spleen_8


### PR DESCRIPTION
ESPHome deprecated the top-level `disp_bg_color` LVGL option in favor of a `bottom_layer` block. Building currently logs:

```
WARNING The property 'disp_bg_color' is deprecated, use 'bottom_layer' instead.
```

`bottom_layer` is a special layer rendered behind all pages; setting its `bg_color` reproduces the old screen-background behavior. No visual change.