### PR TITLE
Add CONTRIBUTING guide, PR template, and issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. Please strip IPs, MACs, and tokens from any logs you paste.
+  - type: dropdown
+    id: controller
+    attributes:
+      label: Controller
+      options:
+        - Apollo M-1 rev4
+        - Apollo M-1 rev6
+        - Adafruit Matrix Portal S3
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: esphome-version
+    attributes:
+      label: ESPHome version
+      placeholder: "2026.7.x"
+    validations:
+      required: true
+  - type: input
+    id: firmware
+    attributes:
+      label: Firmware source
+      description: The prebuilt release tag you flashed, or the commit you built from.
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did you expect, what happened instead, and how can it be reproduced?
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: ESPHome build or runtime logs. This is automatically formatted, so no backticks are needed.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation (Wiki)
+    url: https://github.com/pavlov-net/hub75-studio/wiki
+    about: Installation, customization, page configs, and troubleshooting guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,17 @@
+name: Feature or page request
+description: Suggest a new page, controller, or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would you like to see?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: How would you use it?
+      description: The Home Assistant integration or hardware this depends on, if any.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!-- Thanks for contributing. Keep it to one logical change per PR. -->
+
+## What and why
+
+<!-- What does this change do, and why? Link any related issue. -->
+
+## Testing
+
+- [ ] Ran `scripts/yaml_lint.py` against the affected config
+- [ ] Built at least one controller (`uv run esphome run <file>.factory.yaml`)
+- [ ] Tested on hardware
+
+Controller(s) tested:
+ESPHome version:
+
+## Checklist
+
+- [ ] One logical change
+- [ ] No secrets, personal entity IDs, or tokens committed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to HUB75 Studio
+
+Thanks for helping improve HUB75 Studio. The project is ESPHome YAML built on ESP-IDF with LVGL. Most contributions are new pages, added controller support, or fixes to existing configs.
+
+## Before you start
+
+- For anything non-trivial (a new page, a new controller, a behavior change), open an issue first so the approach can be discussed before you invest time.
+- Small fixes such as typos, deprecation warnings, or one-line corrections can go straight to a pull request.
+
+## Development setup
+
+Requires Python 3.11+ and [uv](https://docs.astral.sh/uv/getting-started/installation/). ESPHome and its pinned dependencies install automatically from the lockfile.
+
+```bash
+# Build and flash a controller (USB or OTA)
+uv run esphome run apollo-automation-m1-rev6.factory.yaml
+```
+
+No local Python toolchain? Use the Docker image:
+
+```bash
+docker run --rm -it -v "$PWD":/config esphome/esphome run apollo-automation-m1-rev6.factory.yaml
+```
+
+Builds target ESP-IDF only. Arduino is not supported.
+
+## Repository layout
+
+- `*.factory.yaml` files are the factory configs. GitHub Releases builds prebuilt firmware from these.
+- `*.yaml` (non-factory) files are the config a device generates after you Adopt it in ESPHome.
+- `packages/common/` holds the shared theme, DDP, utilities, and WizMote support.
+- `packages/controllers/` holds hardware-specific configuration.
+- `packages/pages/` holds the drop-in LVGL pages and effects.
+
+Edit the package files under `packages/`, not a generated per-device config. Both the factory and non-factory entrypoints are built in CI, so a change to a shared package must build cleanly for every controller.
+
+## Before you open a PR
+
+1. Lint the config you touched. The linter checks includes, secrets, and substitution precedence:
+   ```bash
+   uv run python scripts/yaml_lint.py apollo-automation-m1-rev6.yaml
+   ```
+2. Build at least one controller that exercises your change, on hardware when possible.
+3. Keep secrets and personal entity IDs out of the repo. Strip IPs, MACs, and tokens from any logs you paste.
+
+## Pull requests
+
+- One logical change per PR.
+- Use a short, descriptive title, for example `Fix timer page hardcoding friendly name`.
+- CI builds every controller against ESPHome stable, beta, and dev. All three must pass.
+- Release notes are generated from labels, so a maintainer may add one such as `bug`, `enhancement`, or `documentation` at merge time.
+
+## External components
+
+Pages and effects depend on external components maintained separately:
+
+- [lvgl-ddp-stream](https://github.com/pavlov-net/lvgl-ddp-stream)
+- [lvgl-canvas-fx](https://github.com/pavlov-net/lvgl-canvas-fx)
+- [lvgl-page-manager](https://github.com/pavlov-net/lvgl-page-manager)
+
+Pin these by tag or commit SHA rather than a moving branch so builds stay reproducible.
+
+## License
+
+By contributing, you agree that your changes are licensed under the repository's [MIT license](LICENSE). Fonts and icons carry their own terms in [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md).


### PR DESCRIPTION
The repo has no contributor-facing docs yet. This adds:

- `CONTRIBUTING.md` covering the uv/Docker build, `scripts/yaml_lint.py`, the factory vs non-factory package layout, and PR conventions (stable/beta/dev must all build).
- `.github/PULL_REQUEST_TEMPLATE.md` with a short what/why, testing, and no-secrets checklist.
- Bug and feature issue forms under `.github/ISSUE_TEMPLATE/`, plus a `config.yml` linking the Wiki.

All content is drawn from the existing README and CI. Adjust or drop anything that does not match how you would like contributions handled.