### PR TITLE
Add ESPHome project metadata to source builds

### DIFF
--- a/packages/common/esphome-version.yaml
+++ b/packages/common/esphome-version.yaml
@@ -1,6 +1,13 @@
 # © Copyright 2025 Stuart Parmenter
 # SPDX-License-Identifier: MIT
 
-# Enforce minimum ESPHome version
+# Enforce minimum ESPHome version and identify the project to clients
 esphome:
   min_version: 2026.7.0
+
+  # The .factory.yaml configs declare their own project block, which wins over
+  # this one, so release builds keep the version the publish workflow injects.
+  # Keep in sync with the version in pyproject.toml.
+  project:
+    name: pavlov-net.hub75-studio
+    version: "0.7.2"


### PR DESCRIPTION
Devices built from the source configs currently report no project to Home Assistant: the device page shows no project name or version, and a blueprint has no way to narrow an entity picker to hub75-studio devices (the only filter available today is "any ESPHome device"). The `.factory.yaml` configs already declare `project:`, so web-installer devices identify themselves and source-built ones do not.

This adds the block to `packages/common/esphome-version.yaml`:

```yaml
esphome:
  min_version: 2026.7.0

  project:
    name: pavlov-net.hub75-studio
    version: "0.7.2"
```

Two choices worth calling out:

- **Location.** Every device config already includes this package, factory and non-factory, so the metadata arrives without touching any root YAML. That matters for people who copied a root config months ago: their local copy still pulls the shared packages from the repo, so they pick this up on the next build with no edit on their side.
- **Version.** It mirrors the version in `pyproject.toml`, which is one line to bump at release time and travels with the ref, so someone pinning `ref: v0.7.1` gets the version that tag shipped. Happy to use something else if you would rather it read `main` or a date.

The factory configs are unaffected. A `project:` block in the main config overrides one coming from a package, so the release version the publish workflow injects still wins.

Side effect: `ESPHOME_PROJECT_VERSION` becomes the ESP-IDF app version, so the BIOS page's `V:` label now shows `0.7.2` on source builds instead of the ESPHome version. Factory builds already behaved this way.

Validated with `esphome config` on ESPHome 2026.8.1:

- `apollo-automation-m1-rev6.factory.yaml` (local includes) resolves to `name: pavlov-net.hub75-studio` / `version: dev`, confirming the factory block still overrides the package.
- A copy of `apollo-automation-m1-rev6.yaml` with the `esphome-version.yaml` entry pointed at the local file (the remote package still resolves from `main`, which does not have this change yet) resolves to `version: 0.7.2`.

Both exit 0 with no new warnings.
