### PR TITLE
Shared Scroll Speed control for scrolling pages

### DIFF
--- a/packages/common/utils.yaml
+++ b/packages/common/utils.yaml
@@ -29,6 +29,7 @@ button:
     name: "ESP Reboot"
     entity_category: "diagnostic"
 
+
 # Matrix display controls
 switch:
   - platform: template
@@ -47,6 +48,19 @@ switch:
           brightness: 0
 
 number:
+  # Shared scroll speed for pages with scrolling text (1 slow .. 10 fast).
+  # Pages map the value to their own animation timing.
+  - platform: template
+    name: "Scroll Speed"
+    id: shared_scroll_speed
+    icon: "mdi:speedometer"
+    entity_category: config
+    min_value: 1
+    max_value: 10
+    step: 1
+    initial_value: 5
+    optimistic: true
+    restore_value: true
   - platform: template
     name: "Brightness"
     id: brightness

--- a/packages/pages/sendspin.yaml
+++ b/packages/pages/sendspin.yaml
@@ -75,25 +75,8 @@ sensor:
     type: track_duration
     id: sendspin_track_duration
 
-number:
-  - platform: template
-    name: "SendSpin Scroll Speed"
-    id: sendspin_scroll_speed
-    icon: "mdi:speedometer"
-    entity_category: config
-    min_value: 1
-    max_value: 10
-    step: 1
-    initial_value: 5
-    optimistic: true
-    restore_value: true
-    on_value:
-      - lambda: |-
-          uint32_t anim_ms = (uint32_t)(11000 - x * 1000);
-          lv_obj_set_style_anim_time(id(sendspin_now_playing_label), anim_ms, LV_PART_MAIN);
-          // Force the running scroll animation to restart with the new speed
-          lv_label_set_long_mode(id(sendspin_now_playing_label), LV_LABEL_LONG_CLIP);
-          lv_label_set_long_mode(id(sendspin_now_playing_label), LV_LABEL_LONG_SCROLL_CIRCULAR);
+# Scroll speed comes from the shared "Scroll Speed" number in common/utils.yaml;
+# the subscription lives in the esphome: on_boot block below.
 
 # Poll track progress while playing and drive the progress bar.
 # Runs regardless of which page is active so the bar is ready on page switch.
@@ -149,6 +132,14 @@ esphome:
   on_boot:
     - priority: -100
       then:
+        - lambda: |-
+            // Slider moves on the shared Scroll Speed re-time the running scroll
+            id(shared_scroll_speed).add_on_state_callback([](float sp) {
+              uint32_t anim_ms = (uint32_t)(11000 - sp * 1000);
+              lv_obj_set_style_anim_time(id(sendspin_now_playing_label), anim_ms, LV_PART_MAIN);
+              lv_label_set_long_mode(id(sendspin_now_playing_label), LV_LABEL_LONG_CLIP);
+              lv_label_set_long_mode(id(sendspin_now_playing_label), LV_LABEL_LONG_SCROLL_CIRCULAR);
+            });
         - lambda: |-
             id(sendspin_hub).add_metadata_update_callback(
               [](const auto &m) {
@@ -214,5 +205,5 @@ lvgl:
         then:
           - lambda: |-
               id(sendspin_art_output).start();
-              uint32_t anim_ms = (uint32_t)(11000 - id(sendspin_scroll_speed).state * 1000);
+              uint32_t anim_ms = (uint32_t)(11000 - id(shared_scroll_speed).state * 1000);
               lv_obj_set_style_anim_time(id(sendspin_now_playing_label), anim_ms, LV_PART_MAIN);


### PR DESCRIPTION
Adds a shared "Scroll Speed" number (1 slow to 10 fast, config category, restored across reboots) to `common/utils.yaml`, next to Brightness, and migrates SendSpin to it. Pages subscribe with `add_on_state_callback` at boot and map the value to their own animation timing, so the shared entity stays page-agnostic and slider moves re-time a running scroll immediately.

Motivation: with more than one scrolling page (SendSpin plus the Team Tracker page in #148) per-page speed entities pile up on the device page. One knob covers them all; any future page with scrolling text subscribes the same way.

Breaking change: the "SendSpin Scroll Speed" entity is removed in favor of the shared one (old entity shows as orphaned in HA once, then can be deleted).

Tested on an Apollo M-1: slider moves re-time the SendSpin scroll and the #148 ticker instantly, settings survive reboots. #148 will be updated to subscribe to this entity if this lands.
