### PR TITLE
Clarify Now Playing requires 128x64 for full layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Built on **ESPHome** with **LVGL** for smooth graphics, everything integrates se
 ## Features
 
 **Transform Your Matrix Into:**
-- 🎵 **Music Dashboard** — Album art, track info, progress bar (multi‑room support)
+- 🎵 **Music Dashboard** — Album art, track info, progress bar (multi‑room support; full layout needs 128x64. Single 64x64 panel shows album art only)
 - 🏈 **Sports Center** — Live scores for multiple teams (works with ha‑teamtracker)
 - 🌤️ **Info Display** — Weather, time, person status, timers, QR codes
 - 📊 **Visualizer** — Real‑time audio spectrum, presence radar

--- a/packages/pages/now-playing.yaml
+++ b/packages/pages/now-playing.yaml
@@ -2,7 +2,11 @@
 # SPDX-License-Identifier: MIT
 
 # Now Playing (LVGL + DDP)
-# This is designed to work with two horizontal panels (128x64)
+# HARDWARE REQUIREMENT: This page's full layout (album art + track info +
+# progress bar) is designed for a 128x64 display (two horizontal 64x64
+# panels chained). On a single 64x64 panel, ONLY the album art is shown --
+# track title/artist and the progress bar are not displayed. This is by
+# design, not a bug.
 #
 # Required vars:
 #   uid: Unique identifier for this instance (e.g., "living_room")


### PR DESCRIPTION
The Now Playing page shows **album art only** on a single 64x64 panel — track info and the progress bar require a 128x64 (two-panel) display.

Currently this is noted only as a passive "designed to work with two horizontal panels" comment inside `now-playing.yaml`, which isn't surfaced where users would see it before configuring. This trips up single-panel M-1 owners (raised and acknowledged in #26).

Changes:
- **README.md**: note the requirement on the Music Dashboard feature line
- **packages/pages/now-playing.yaml**: strengthen the header comment to state clearly that a single 64x64 panel shows album art only (by design, not a bug)

Docs-only; no functional changes.